### PR TITLE
Update Readme to correct GraphQL switch

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ $ php artisan artomator.graphql.query <MODEL_NAME>
 $ php artisan artomator.graphql:type <MODEL_NAME>
 ```
 
-For the GraphQL commands you can also provide an additional switch `--gql=AlternativeGraphqlName` which will allow you to customise the name used by the GraphQL engine. If this is omitted the model name will be used instead.
+For the GraphQL commands you can also provide an additional switch `--gqlName=AlternativeGraphqlName` which will allow you to customise the name used by the GraphQL engine. If this is omitted the model name will be used instead.
 
 ### `artomator.publish:templates`
 


### PR DESCRIPTION
Noticed that the Readme file was incorrect and as such needs to be updated to suit the correct switch name `--gqlName`.