### PR TITLE
🐞 Fix relocated default-schema from lighthouse

### DIFF
--- a/src/ArtomatorServiceProvider.php
+++ b/src/ArtomatorServiceProvider.php
@@ -39,7 +39,7 @@ class ArtomatorServiceProvider extends ServiceProvider
     {
         $configPath = __DIR__.'/../config/artomator.php';
         $configPathInfyom = __DIR__.'/../../../infyomlabs/laravel-generator/config/laravel_generator.php';
-        $schemaPath = __DIR__.'/../../../nuwave/lighthouse/assets/default-schema.graphql';
+        $schemaPath = __DIR__.'/../../../nuwave/lighthouse/src/default-schema.graphql';
         $configPathNuwave = __DIR__.'/../../../nuwave/lighthouse/src/lighthouse.php';
 
         $this->publishes(


### PR DESCRIPTION
Fix issue that the publishing of the files can't find the file in question. Lighthouse moved the file to a new location. This updates the path.

A future improvement would be to fire the artisan command for lighthouse directly - thereby removing the need for the path location to be maintained.