### PR TITLE
🐞 Fix issue with views flag not being checked properly

### DIFF
--- a/src/Generators/Scaffold/VueGenerator.php
+++ b/src/Generators/Scaffold/VueGenerator.php
@@ -71,7 +71,7 @@ class VueGenerator extends BaseGenerator
 
         $this->commandData->commandComment("\nGenerating Vues...");
 
-        if (true === $this->commandData->getOption('views')) {
+        if (false !== $this->commandData->getOption('views')) {
             $vuesToBeGenerated = explode(',', $this->commandData->getOption('views'));
 
             if (true === in_array('index', $vuesToBeGenerated)) {


### PR DESCRIPTION
The check to see if the views flag was being used was not being correctly checked. The `getOptions()` function returns `false` or the value. Therefore doing a `true === ...` would never pass.